### PR TITLE
Vship 293 webhooks

### DIFF
--- a/src/Actions/HandleWebhooks.php
+++ b/src/Actions/HandleWebhooks.php
@@ -23,7 +23,7 @@ trait HandleWebhooks
         $event = WebhookUtil::constructEvent($payload, $headerSignature, $secret);
 
         return new Webhook(
-            type: $event->objectType->value,
+            type: $event->webhookType,
             object: Util::convertToVshipObject(
                 targetClass: $event->objectType->getClass(),
                 data: $event->objectData,

--- a/src/DTO/Webhook.php
+++ b/src/DTO/Webhook.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Vship\DTO;
 
+use Vship\Enum\WebhookType;
+
 class Webhook
 {
     public function __construct(
-        public readonly string $type,
+        public readonly WebhookType $type,
         public readonly object $object,
     ) {}
 }

--- a/src/DTO/Webhook/Event.php
+++ b/src/DTO/Webhook/Event.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Vship\DTO\Webhook;
 
 use Vship\Enum\Webhook\ObjectType;
+use Vship\Enum\WebhookType;
 
 class Event
 {
     public function __construct(
         public readonly ObjectType $objectType,
+        public readonly WebhookType $webhookType,
         public readonly array $objectData,
     ) {}
 }

--- a/src/Enum/WebhookType.php
+++ b/src/Enum/WebhookType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vship\Enum;
+
+enum WebhookType: string
+{
+    case LABELS_CREATED = 'labels.created';
+    case LABELS_ERROR = 'labels.error';
+}

--- a/src/Models/Shipment/Error.php
+++ b/src/Models/Shipment/Error.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vship\Models\Shipment;
+
+final class Error
+{
+    public function __construct(
+        public readonly ?string $carrierMessage,
+        public readonly ?string $carrierCode,
+        public readonly ?string $carrierDetails,
+    ) {}
+}

--- a/src/Models/Shipment/Shipment.php
+++ b/src/Models/Shipment/Shipment.php
@@ -84,4 +84,7 @@ final class Shipment
 
     /** @var Parcel[]|null */
     public ?array $parcels = null;
+
+    /** @var Error[]|null  */
+    public ?array $error = null;
 }

--- a/src/Tests/Cases/Actions/ManageWebhooksTest.php
+++ b/src/Tests/Cases/Actions/ManageWebhooksTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Vship\Actions\HandleWebhooks;
 use Vship\Client;
+use Vship\Enum\WebhookType;
 use Vship\Models\Shipment\Shipment;
 use Vship\Tests\Traits\TestsWebhooks;
 
@@ -25,12 +26,22 @@ class ManageWebhooksTest extends TestCase
         $this->client = new Client('test_secret');
     }
 
-    public function testWithCorrectPayload()
+    public function testLabelsCreatedWebhook()
     {
         list($payload, $secret, $signature) = $this->getLabelsCreatedWebhook();
         $webhook = $this->client->handleWebhook($payload, $signature, $secret);
         $shipment = $webhook->object;
         $this->assertInstanceOf(Shipment::class, $shipment);
-        $this->assertEquals('shipment', $webhook->type);
+        $this->assertEquals(WebhookType::LABELS_CREATED, $webhook->type);
+    }
+
+    public function testLabelsFailedWebhook()
+    {
+        list($payload, $secret, $signature) = $this->getLabelsFailedWebhook();
+        $webhook = $this->client->handleWebhook($payload, $signature, $secret);
+        $shipment = $webhook->object;
+        $this->assertInstanceOf(Shipment::class, $shipment);
+        $this->assertEquals(WebhookType::LABELS_ERROR, $webhook->type);
+        $this->assertEquals('WeightInKg must be greater than 0', $shipment->error[0]->carrierMessage);
     }
 }

--- a/src/Tests/Traits/TestsWebhooks.php
+++ b/src/Tests/Traits/TestsWebhooks.php
@@ -11,6 +11,17 @@ trait TestsWebhooks
     protected function getLabelsCreatedWebhook(): array
     {
         $payload = Utils::getFixture('webhook/labels-created.json');
+        return $this->prepareSignature($payload);
+    }
+
+    protected function getLabelsFailedWebhook(): array
+    {
+        $payload = Utils::getFixture('webhook/labels-failed.json');
+        return $this->prepareSignature($payload);
+    }
+
+    private function prepareSignature(string $payload): array
+    {
         $secret = 'test_secret';
         $signature = hash_hmac('sha256', $payload, $secret);
         return [$payload, $secret, $signature];

--- a/src/Tests/fixtures/webhook/labels-created.json
+++ b/src/Tests/fixtures/webhook/labels-created.json
@@ -1,1 +1,42 @@
-{"data":{"object_type":"shipment","shipment":{"id":"someId","reference":"bring--homee-DK-webhook","sendable":{"type":"object","id":"objectId","name":"someName"},"carrier":{"id":"carrierId","name":"Test","carrier_identification":"11111111118800043"},"label":{"type":"dispatch","format":"pdf","temporary_url":"https:\/\/shippii-dev-media.s3.eu-central-1.amazonaws.com\/labels\/test"},"parcels":[{"id":"11111H7GNAV4NXZWX0BJ2HYYXS","sendable_reference":"bring--homee-DK-webhook","barcode":"11111H7GNAV4NXZWX0BJ2HYYXS","carrier_number":"111112151856264005","carrier_tracking_url":"https:\/\/tracking.bring.dk\/tracking\/11111151688800043","weight":10000,"volume":"5003.0000","volumetric_weight":null,"label":{"type":"dispatch","format":"pdf","temporary_url":"https:\/\/shippii-dev-media.s3.eu-central-1.amazonaws.com\/labels\/test"}}]}}}
+{
+  "data": {
+    "object_type": "shipment",
+    "event_type": "labels.created",
+    "shipment": {
+      "id": "01FAKEID1DHGH5RZ7KTB2P1A93D",
+      "reference": "5009135272589117",
+      "sendable": {
+        "type": "object",
+        "id": "01FAKEIDCVWYNEXQTDPXK538AY",
+        "name": "Demo Object DK"
+      },
+      "carrier": {
+        "id": "01FAKEIDMP79F5JW0N38WC68VD",
+        "name": "Demo Bring",
+        "carrier_identification": "123456789012345678"
+      },
+      "label": {
+        "type": "dispatch",
+        "format": "pdf",
+        "temporary_url": "https://example.com/labels/01FAKEID1DHGH5RZ7KTB2P1A93D/01FAKEID3GT73ZDH3M7E6D4B3G6_shipment_dispatch.pdf"
+      },
+      "parcels": [
+        {
+          "id": "01FAKEID1E25S79R2ZY0TR0RFSD",
+          "sendable_reference": "5009135272589117",
+          "barcode": "01FAKEID1E25S79R2ZY0TR0RFSD",
+          "carrier_number": "123456789012345678",
+          "carrier_tracking_url": "https://example.com/tracking/123456789012345678",
+          "weight": 100,
+          "volume": "100.0000",
+          "volumetric_weight": null,
+          "label": {
+            "type": "dispatch",
+            "format": "pdf",
+            "temporary_url": "https://example.com/labels/01FAKEID1DHGH5RZ7KTB2P1A93D/01FAKEID35PJRRVVRARA97BDGSQ_parcel_dispatch.pdf"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/Tests/fixtures/webhook/labels-failed.json
+++ b/src/Tests/fixtures/webhook/labels-failed.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "object_type": "shipment",
+    "event_type": "labels.error",
+    "shipment": {
+      "id": "01FAKEIDV5K56SY5CE6TA615Q9",
+      "reference": "4161302962013298",
+      "sendable": {
+        "type": "object",
+        "id": "01FAKEIDCVWYNEXQTDPXK538AY",
+        "name": "Demo Object DK"
+      },
+      "carrier": {
+        "id": "01FAKEIDMP79F5JW0N38WC68VD",
+        "name": "Demo Bring"
+      },
+      "error": [
+        {
+          "carrierMessage": "WeightInKg must be greater than 0",
+          "carrierCode": "BOOK-VALIDATION-001",
+          "carrierDetails": null
+        }
+      ]
+    }
+  }
+}

--- a/src/Util/Webhook.php
+++ b/src/Util/Webhook.php
@@ -6,6 +6,7 @@ namespace Vship\Util;
 
 use Vship\DTO\Webhook\Event;
 use Vship\Enum\Webhook\ObjectType;
+use Vship\Enum\WebhookType;
 use Vship\Exceptions\FailedActionException;
 use Vship\Exceptions\SignatureVerificationException;
 
@@ -32,6 +33,10 @@ abstract class Webhook
 
         $objectType = $payloadArr['data']['object_type'];
 
-        return new Event(ObjectType::from($objectType), $payloadArr['data'][$objectType]);
+        return new Event(
+            objectType: ObjectType::from($objectType),
+            webhookType: WebhookType::from($payloadArr['data']['event_type'] ?? ''),
+            objectData: $payloadArr['data'][$objectType],
+        );
     }
 }


### PR DESCRIPTION
This pull request includes significant changes to the webhook handling and error management in the Vship system. The most important changes include the introduction of a new `WebhookType` enum, modifications to the `Webhook` and `Event` DTOs, and updates to the test cases and fixtures to accommodate these changes.

### Webhook Handling Updates:
* [`src/Actions/HandleWebhooks.php`](diffhunk://#diff-c116e4fc55857754e7c0b1f3241901c4553b5b61362e827da0080e2edf561527L26-R26): Changed the `type` parameter in the `Webhook` constructor to use `webhookType` instead of `objectType->value`.
* [`src/Util/Webhook.php`](diffhunk://#diff-df26a9182817f4196cfd7e35a8724263c8cb9e0216303caafd52a20096529f77L35-R40): Updated the `constructEvent` method to include `webhookType` in the `Event` constructor.

### DTO Modifications:
* [`src/DTO/Webhook.php`](diffhunk://#diff-4e204888025e3c1109d768f1e8ca93cee9f0e990d512db6c12838273f26f894dR7-R12): Updated the `type` property in the `Webhook` class to use the `WebhookType` enum.
* [`src/DTO/Webhook/Event.php`](diffhunk://#diff-d1c34c005637a7fe56ef6611394c78811a3c4b377a5f4afd287b2d6ecac7b7c8R8-R14): Added the `webhookType` property to the `Event` class.

### Enum Introduction:
* [`src/Enum/WebhookType.php`](diffhunk://#diff-102407e96e07f8c0b4cf044018fe37fe8076307bc7871e2e77e31abb0fc05d99R1-R11): Introduced a new `WebhookType` enum with cases for `LABELS_CREATED` and `LABELS_ERROR`.

### Error Handling:
* [`src/Models/Shipment/Error.php`](diffhunk://#diff-0fdd27dc963523fb0617f7379405590b033a9ab8591b827a6ce1bb72d523691dR1-R14): Added a new `Error` class to represent shipment errors.
* [`src/Models/Shipment/Shipment.php`](diffhunk://#diff-38bc27f519edf1e514f15b76e91b7f3d67e89e4696302bea84ac975dbfcec97dR87-R89): Added an `error` property to the `Shipment` class to hold an array of `Error` objects.

### Test Cases and Fixtures:
* [`src/Tests/Cases/Actions/ManageWebhooksTest.php`](diffhunk://#diff-8acf1fa07d178752d49073c5b5b67b523cd39328d7df68fd8d9c615227fc8299L28-R45): Updated test cases to use the new `WebhookType` enum and added a test for `LABELS_ERROR` webhook.
* [`src/Tests/Traits/TestsWebhooks.php`](diffhunk://#diff-22a17f564afa54a3181663661b21fe59a77e1206da24936b353b0531d6c08d7cR14-R24): Added methods to handle `labels-failed` webhook and prepare signatures.
* [`src/Tests/fixtures/webhook/labels-created.json`](diffhunk://#diff-b9b302f71f6a88781d39c5f4eeabf41e6cc1b154c22538ef4f1d7c08272aa85fL1-R42): Updated fixture to include `event_type` field.
* [`src/Tests/fixtures/webhook/labels-failed.json`](diffhunk://#diff-ca61d654b03bc131bc8bf999e0c9b064259ca1ce81c193c4f1fc6bc9df3d88f5R1-R26): Added a new fixture for `labels-failed` webhook.