### PR TITLE
VSHIP-377-release-webhooks-on-sdk.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -50,10 +50,12 @@ class Client
      */
     public string $baseUrl;
 
+    public const SANDBOX_URL = 'https://api-dev.vship.dev/';
+
     /**
      * Create a new Forge instance.
      */
-    public function __construct(?string $apiKey = null, ?HttpClient $guzzle = null, ?string $baseUrl = null)
+    public function __construct(?string $apiKey = null, ?HttpClient $guzzle = null, ?string $baseUrl = self::SANDBOX_URL)
     {
         if ($apiKey !== null) {
             $this->setApiKey($apiKey, $baseUrl, $guzzle);
@@ -70,7 +72,7 @@ class Client
      * @param  int  $timeout
      * @return $this
      */
-    public function setTimeout($timeout)
+    public function setTimeout($timeout): static
     {
         $this->timeout = $timeout;
 
@@ -82,17 +84,17 @@ class Client
      *
      * @return int
      */
-    public function getTimeout()
+    public function getTimeout(): int
     {
         return $this->timeout;
     }
 
     /**
-     * Set the api key and setup the guzzle request object.
+     * Set the api key and set up the guzzle request object.
      *
      * @return $this
      */
-    public function setApiKey(string $apiKey, string $baseUrl, $guzzle = null)
+    public function setApiKey(string $apiKey, string $baseUrl, HttpClient $guzzle = null): static
     {
         $this->guzzle = $guzzle ?: new HttpClient([
             'base_uri' => $baseUrl,
@@ -108,28 +110,8 @@ class Client
     }
 
     /**
-     * Transform the items of the collection to the given class.
-     *
-     * @param  array  $collection
-     * @param  string  $class
-     * @param  array  $extraData
-     * @param  array  $meta
-     */
-    protected function transformCollection($collection, $class, $extraData = [], $meta = []): array
-    {
-        $collection = array_map(function ($data) use ($class, $extraData) {
-            if (is_array($data)) {
-                return new $class($data + $extraData, $this);
-            }
-        }, $collection);
-
-        $collection['meta'] = $meta;
-
-        return $collection;
-    }
-
-    /**
      * Prepare query parameters string.
+     * @param array<string, int|string|float> $parameters
      */
     protected function prepareRequestParameters(array $parameters): string
     {


### PR DESCRIPTION
This pull request to `src/Client.php` includes changes to improve the type safety of method signatures and to set a default base URL for the `Client` class. The most important changes include adding a constant for the sandbox URL, updating the constructor to use this constant, and enhancing method signatures with return types and static return types.

Improvements to type safety and method signatures:

* Added `SANDBOX_URL` constant and updated the constructor to use `SANDBOX_URL` as the default base URL. (`src/Client.php`)
* Updated `setTimeout` method to include a `static` return type. (`src/Client.php`)
* Updated `getTimeout` method to include an `int` return type. (`src/Client.php`)
* Updated `setApiKey` method to include a `static` return type and specified the type for `$guzzle` parameter as `HttpClient`. (`src/Client.php`)

Removal of unnecessary methods:

* Removed the `transformCollection` method which was no longer in use. (`src/Client.php`)